### PR TITLE
Set `autoDeploy` to false

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -2,6 +2,7 @@ services:
 - type: web
   name: hasura
   env: docker
+  autoDeploy: false
   healthCheckPath: /healthz
   envVars:
   - key: HASURA_GRAPHQL_DATABASE_URL


### PR DESCRIPTION
We shouldn't auto-update `hasura` instances created by this repo. Users can choose to manually deploy from `master` to upgrade.